### PR TITLE
Description of Zenodo Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,30 @@ pre-print style journal articles that would otherwise go on the arxiv
 (draft)
 Upload to Zenodo and then sumbit to the AIAC Community where it will be moderated. 
 
+The Archive may provide some tools to ease the work of submitting content. Christopher Erdmann has suggested that Harvard CfA may make a Wordpress Plugin. LSST (@jonathansick) and others will probably make a Python tool for plaintext static blogs.
+
 ### Guidelines for Submission's content and format
 
 It should be easily and openly readable, e.g., plaintext/markdown and images or an ipython notebook. 
 If appropriate, a PDF rendering is encouraged.
-
 Something about URL and/or original blog.
+
+### REST Metadata Guidelines
+
+Zenodo's [REST API specifies metadata](https://zenodo.org/dev#restapi-rep-meta) that can be included with a submission. This section provides some guidelines on how these fields should be used.
+
+- `creators`. We mandate that the authors include an `orcid` field to encourage author disambiguation with [ORCID](http://orcid.org). The `affiliation` field is also mandated.
+- `title` should match the original title of the work on the web.
+- `publication_date` should be the date the work was originally published to the web.
+- `description` will be mapped to the work's abstract on ADS. It can be drawn from the original content or be created for the deposition. It cannot be empty.
+- `access_right` must be `'open'`. (Does it make sense to allow `closed` or `embargoed`?)
+- `license` must be specified.
+- `references`. Publishers must strive to properly cite material quoted or linked to through this field.
+- `keywords`. Should we mandate a controlled keyword vocabulary?
+- `upload_type`. We should allow any of these: `publication`, `poster`, `presentation`, `dataset`, `image`, `video`, `software`.
+- `publication_type` if the material is a `publication`, such as a blog post, how do we describe that? `other`? `technicalnote`? `report`?
+- `communities` must be the Publisher's own community within AIAC.
+- `related_identifiers` should be automatically amended after submission to include the ADS BibCode.
 
 ## How ADS indexes the Archive
 


### PR DESCRIPTION
We should mandate some standards for the metadata associated with works.
See the Zenodo API docs at https://zenodo.org/dev#restapi-rep-meta.
